### PR TITLE
IE 11 support

### DIFF
--- a/lib/react-download.js
+++ b/lib/react-download.js
@@ -122,10 +122,17 @@ var Download = function (_Component) {
       function export_raw(name, data) {
         var urlObject = window.URL || window.webkitURL || window;
         var export_blob = new Blob([data]);
-        var save_link = document.createElementNS("http://www.w3.org/1999/xhtml", "a");
-        save_link.href = urlObject.createObjectURL(export_blob);
-        save_link.download = name;
-        fake_click(save_link);
+
+        if ('download' in HTMLAnchorElement.prototype) {
+          var save_link = document.createElementNS("http://www.w3.org/1999/xhtml", "a");
+          save_link.href = urlObject.createObjectURL(export_blob);
+          save_link.download = name;
+          fake_click(save_link);
+        } else if ('msSaveBlob' in navigator) {
+          navigator.msSaveBlob(export_blob, name);
+        } else {
+          throw new Error("Neither a[download] nor msSaveBlob is available");
+        }
       }
       export_raw(fileName, fileContent);
     }

--- a/lib/react-download.js
+++ b/lib/react-download.js
@@ -123,13 +123,16 @@ var Download = function (_Component) {
         var urlObject = window.URL || window.webkitURL || window;
         var export_blob = new Blob([data]);
 
-        if ('download' in HTMLAnchorElement.prototype) {
+        if ('msSaveBlob' in navigator) {
+          // Prefer msSaveBlob if available - Edge supports a[download] but
+          // ignores the filename provided, using the blob UUID instead.
+          // msSaveBlob will respect the provided filename
+          navigator.msSaveBlob(export_blob, name);
+        } else if ('download' in HTMLAnchorElement.prototype) {
           var save_link = document.createElementNS("http://www.w3.org/1999/xhtml", "a");
           save_link.href = urlObject.createObjectURL(export_blob);
           save_link.download = name;
           fake_click(save_link);
-        } else if ('msSaveBlob' in navigator) {
-          navigator.msSaveBlob(export_blob, name);
         } else {
           throw new Error("Neither a[download] nor msSaveBlob is available");
         }

--- a/src/react-download.jsx
+++ b/src/react-download.jsx
@@ -33,7 +33,12 @@ export default class Download extends Component {
       let urlObject = window.URL || window.webkitURL || window;
       let export_blob = new Blob([data]);
 
-      if ('download' in HTMLAnchorElement.prototype) {
+      if ('msSaveBlob' in navigator) {
+        // Prefer msSaveBlob if available - Edge supports a[download] but
+        // ignores the filename provided, using the blob UUID instead.
+        // msSaveBlob will respect the provided filename
+        navigator.msSaveBlob(export_blob, name);
+      } else if ('download' in HTMLAnchorElement.prototype) {
         let save_link = document.createElementNS(
           "http://www.w3.org/1999/xhtml",
           "a"
@@ -41,8 +46,6 @@ export default class Download extends Component {
         save_link.href = urlObject.createObjectURL(export_blob);
         save_link.download = name;
         fake_click(save_link);
-      } else if ('msSaveBlob' in navigator) {
-        navigator.msSaveBlob(export_blob, name);
       } else {
         throw new Error("Neither a[download] nor msSaveBlob is available");
       }

--- a/src/react-download.jsx
+++ b/src/react-download.jsx
@@ -32,13 +32,20 @@ export default class Download extends Component {
     function export_raw(name, data) {
       let urlObject = window.URL || window.webkitURL || window;
       let export_blob = new Blob([data]);
-      let save_link = document.createElementNS(
-        "http://www.w3.org/1999/xhtml",
-        "a"
-      );
-      save_link.href = urlObject.createObjectURL(export_blob);
-      save_link.download = name;
-      fake_click(save_link);
+
+      if ('download' in HTMLAnchorElement.prototype) {
+        let save_link = document.createElementNS(
+          "http://www.w3.org/1999/xhtml",
+          "a"
+        );
+        save_link.href = urlObject.createObjectURL(export_blob);
+        save_link.download = name;
+        fake_click(save_link);
+      } else if ('msSaveBlob' in navigator) {
+        navigator.msSaveBlob(export_blob, name);
+      } else {
+        throw new Error("Neither a[download] nor msSaveBlob is available");
+      }
     }
     export_raw(fileName, fileContent);
   }


### PR DESCRIPTION
Support IE11 by falling back to `navigator.msSaveBlob` if available and `a[download]` is not.

Resolves #10  